### PR TITLE
Make $.range generic

### DIFF
--- a/Dollar/Dollar.swift
+++ b/Dollar/Dollar.swift
@@ -433,18 +433,19 @@ class $ {
     class func pull<T : Equatable>(array: T[], values: T[]) -> T[] {
         return array.filter { !self.contains(values, value: $0) }
     }
-    
-    class func range(endVal: Int) -> Int[] {
+
+    class func range<T : ForwardIndex where T : IntegerLiteralConvertible>(endVal: T) -> T[] {
         return self.range(0, endVal: endVal)
     }
     
-    class func range(startVal: Int, endVal: Int) -> Int[] {
+    class func range<T : ForwardIndex where T.DistanceType : IntegerLiteralConvertible>(startVal: T, endVal: T) -> T[] {
         return self.range(startVal, endVal: endVal, incrementBy: 1)
     }
     
-    class func range(startVal: Int, endVal: Int, incrementBy: Int) -> Int[] {
+    class func range<T : ForwardIndex>(startVal: T, endVal: T, incrementBy: T.DistanceType) -> T[] {
         let range = (startVal..endVal).by(incrementBy)
-        return Int[](range)
+        
+        return sequence(range)
     }
     
     class func sequence<S : Sequence>(seq: S) -> S.GeneratorType.Element[] {

--- a/DollarTests/DollarTests.swift
+++ b/DollarTests/DollarTests.swift
@@ -85,6 +85,10 @@ class DollarTests: XCTestCase {
         XCTAssert($.range(4) as Int[] == [0, 1, 2, 3], "Generates range")
         XCTAssert($.range(1, endVal: 5) as Int[] == [1, 2, 3, 4], "Generates range")
         XCTAssert($.range(0, endVal: 20, incrementBy: 5) as Int[] == [0, 5, 10, 15], "Generates range")
+        
+        XCTAssert($.range(4.0) as Double[] == [0.0, 1.0, 2.0, 3.0], "Generates range of doubles")
+        XCTAssert($.range(-2.0, endVal: 2.0) as Double[] == [-2.0, -1.0, 0.0, 1.0], "Generates range of doubles")
+        XCTAssert($.range(-10.0, endVal: 10.0, incrementBy: 5) as Double[] == [-10.0, -5.0, 0.0, 5.0], "Generates range of doubles")
     }
     
     func testSequence() {


### PR DESCRIPTION
Making $.range a generic function gives us $.range(Double, Double) (and other types) for free.
