### PR TITLE
Rework merge signature

### DIFF
--- a/Dollar/Dollar.swift
+++ b/Dollar/Dollar.swift
@@ -361,19 +361,25 @@ class $ {
         return maxVal
     }
     
-    class func merge<T, U>(original: Dictionary<T, U>, dictionaries: Dictionary<T, U>...) -> Dictionary<T, U> {
-        var result : Dictionary<T, U> = Dictionary<T, U>()
-        
-        for (key, value) in original {
-            result[key] = value
-        }
-        
+    class func merge<T, U>(#dictionaries: Dictionary<T, U>...) -> Dictionary<T, U> {
+        var result = Dictionary<T, U>()
+
         for dict in dictionaries {
             for (key, value) in dict {
                 result[key] = value
             }
         }
-        
+
+        return result
+    }
+
+    class func merge<T>(#arrays: Array<T>...) -> Array<T> {
+        var result = Array<T>()
+
+        for arr in arrays {
+            result += arr
+        }
+
         return result
     }
     

--- a/DollarTests/DollarTests.swift
+++ b/DollarTests/DollarTests.swift
@@ -199,11 +199,17 @@ class DollarTests: XCTestCase {
         XCTAssert($.values(dict) == [1, 2], "Returns correct array with values")
     }
     
-    func tesMerge() {
+    func testMerge() {
         let dict: Dictionary<String, Int> = ["Dog": 1, "Cat": 2]
         let dict2: Dictionary<String, Int> = ["Cow": 3]
         let dict3: Dictionary<String, Int> = ["Sheep": 4]
-        XCTAssert($.merge(dict, dictionaries: dict2, dict3) == ["Dog": 1, "Cat": 2, "Cow": 3, "Sheep": 4], "Returns correct merged dictionary")
+        XCTAssert($.merge(dictionaries: dict, dict2, dict3) == ["Dog": 1, "Cat": 2, "Cow": 3, "Sheep": 4], "Returns correct merged dictionary")
+
+        let arr  = [1, 5]
+        let arr2 = [2, 4]
+        let arr3 = [5, 6]
+        let test = $.merge(arrays: arr, arr2, arr3)
+        XCTAssert(test == [1, 5, 2, 4, 5, 6], "Returns correct merged array")
     }
     
     func testPick() {

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Method | Usage
 **`$.slice`**|Slices the array based on the start and end position. If an end position is not specified it will slice till the end of the array.
 **`$.sortedIndex`**|Gives the smallest index at which a value should be inserted into a given the array is sorted.
 **`$.union`**|Creates an array of unique values, in order, of the provided arrays.
+**`$.merge`**|Creates an array of all values, including duplicates, of the arrays in the order they are provided.
 **`$.uniq`**|Creates a duplicate-value-free version of an array.
 **`$.without`**|Creates an array excluding all provided values.
 **`$.xor`**|Creates an array that is the symmetric difference of the provided arrays.
@@ -451,6 +452,19 @@ Creates an array of unique values, in order, of the provided arrays.
 ```
 $.union([1, 2, 3], [5, 2, 1, 4], [2, 1]) as Int[] 
 => [1, 2, 3, 4, 5]
+```
+
+### merge - `$.merge`
+
+Creates an array of all values, including duplicates, of the arrays in the order they are provided.
+
+```
+let arr  = [1, 5]
+let arr2 = [2, 4]
+let arr3 = [5, 6]
+let result = $.merge(arrays: arr, arr2, arr3)
+result
+=> [1, 5, 2, 4, 5, 6]
 ```
 
 ### uniq - `$.uniq`


### PR DESCRIPTION
I found the syntax of calling merge, supplying the first dictionary, and then having a named argument for the remaining dictionaries fairly awkward, any thoughts?

Given dictionaries `dict`, `dict2` and `dict3` previously merge was
called via:
`$.merge(dict, dictionaries: dict2, dict3)`

With these changes merge becomes:
`$.merge(dictionaries: dict, dict2, dict3)`

and gains
`$.merge(arrays: arr, arr2, arr3)`
