### PR TITLE
Use more descriptive XCTAssert{Equal, EqualObjects, True, False, Nil}

### DIFF
--- a/DollarTests/DollarTests.swift
+++ b/DollarTests/DollarTests.swift
@@ -20,161 +20,147 @@ class DollarTests: XCTestCase {
     }
 
     func testFirst() {
-        XCTAssert($.first([1, 2, 3, 4])! == 1, "Return first element")
-        XCTAssert($.first(Any[]()) == nil, "Returns nil when array is empty")
+        XCTAssertEqualObjects($.first([1, 2, 3, 4])!, 1, "Return first element")
+        XCTAssertNil($.first(NSObject[]()), "Returns nil when array is empty")
     }
 
     func testNoop() {
-        XCTAssert($.noop() == nil, "No op returns nothing")
+        XCTAssertNil($.noop(), "No op returns nothing")
     }
 
     func testCompact() {
-        XCTAssert($.compact([3, nil, 4, 5]) == [3, 4, 5], "Return truth array")
-        XCTAssert($.compact([nil, nil]) as NSObject[] == [], "Return truth array")
+        XCTAssertEqualObjects($.compact([3, nil, 4, 5]), [3, 4, 5], "Return truth array")
+        XCTAssertEqualObjects($.compact([nil, nil]) as NSObject[], [], "Return truth array")
     }
 
     func testFlatten() {
-        XCTAssert($.flatten([[3], 4, 5]) as Int[] == [3, 4, 5], "Return flat array")
-        XCTAssert($.flatten([[3], "Hello", 5]) as NSObject[] == [3, "Hello", 5], "Return flat array")
-        XCTAssert($.flatten([[[3], 4], 5]) as Int[] == [3, 4, 5], "Return flat array")
+        XCTAssertEqualObjects($.flatten([[3], 4, 5]) as Int[], [3, 4, 5], "Return flat array")
+        XCTAssertEqualObjects($.flatten([[3], "Hello", 5]) as NSObject[], [3, "Hello", 5], "Return flat array")
+        XCTAssertEqualObjects($.flatten([[[3], 4], 5]) as Int[], [3, 4, 5], "Return flat array")
     }
 
     func testIndexOf() {
-        XCTAssert($.indexOf(["A", "B", "C"], value: "B") == 1, "Return index of value")
-        XCTAssert($.indexOf([3, 4, 5], value: 5) == 2, "Return index of value")
-        XCTAssert($.indexOf([3, 4, 5], value: 3) == 0, "Return index of value")
-        XCTAssert($.indexOf([3, 4, 5], value: 2) == nil, "Return index of value")
+        XCTAssertEqualObjects($.indexOf(["A", "B", "C"], value: "B"), 1, "Return index of value")
+        XCTAssertEqualObjects($.indexOf([3, 4, 5], value: 5), 2, "Return index of value")
+        XCTAssertEqualObjects($.indexOf([3, 4, 5], value: 3), 0, "Return index of value")
+        XCTAssertNil($.indexOf([3, 4, 5], value: 2), "Return index of value")
     }
 
     func testInitial() {
-        var test = $.initial([3, 4, 5])
-        XCTAssert(test == [3, 4], "Return all values except for last")
-        
-        test = $.initial([3, 4, 5], numElements: 2)
-        XCTAssert(test == [3], "Return all values except for last")
-
-        test = $.initial([3, 4, 5], numElements: 4)
-        XCTAssert(test == [], "Return all values except for last")
+        XCTAssertEqualObjects($.initial([3, 4, 5]), [3, 4], "Return all values except for last")
+        XCTAssertEqualObjects($.initial([3, 4, 5], numElements: 2), [3], "Return all values except for last")
+        XCTAssertEqualObjects($.initial([3, 4, 5], numElements: 4), [], "Return all values except for last")
     }
 
     func testRest() {
-        XCTAssert($.rest([3, 4, 5]) == [4, 5], "Returns all value except for first")
-        XCTAssert($.rest([3, 4, 5], numElements: 2) == [5], "Returns all value except for first")
-        XCTAssert($.rest([3, 4, 5], numElements: 4) == [], "Returns all value except for first")
+        XCTAssertEqualObjects($.rest([3, 4, 5]), [4, 5], "Returns all value except for first")
+        XCTAssertEqualObjects($.rest([3, 4, 5], numElements: 2), [5], "Returns all value except for first")
+        XCTAssertEqualObjects($.rest([3, 4, 5], numElements: 4), [], "Returns all value except for first")
     }
 
     func testLast() {
-        XCTAssert($.last([3, 4, 5])! == 5, "Returns last element in array")
-        XCTAssert($.last(Any[]()) == nil, "Returns nil when array is empty")
+        XCTAssertEqualObjects($.last([3, 4, 5])!, 5, "Returns last element in array")
+        XCTAssertNil($.last(NSObject[]()), "Returns nil when array is empty")
     }
 
     func testFindIndex() {
         let arr = [["age": 36], ["age": 40], ["age": 1]]
-        XCTAssert($.findIndex(arr) { $0["age"] < 20 } == 2, "Returns index of element in array")
+        XCTAssertEqualObjects($.findIndex(arr) { $0["age"] < 20 }, 2, "Returns index of element in array")
     }
 
     func testFindLastIndex() {
         let arr = [["age": 36], ["age": 40], ["age": 1]]
-        XCTAssert($.findLastIndex(arr) { $0["age"] > 30 } == 1, "Returns last index of element in array")
+        XCTAssertEqualObjects($.findLastIndex(arr) { $0["age"] > 30 }, 1, "Returns last index of element in array")
     }
 
     func testLastIndexOf() {
-        XCTAssert($.lastIndexOf([1, 2, 3, 1, 2, 3], value: 2) == 4, "Returns last index of element in array")
+        XCTAssertEqualObjects($.lastIndexOf([1, 2, 3, 1, 2, 3], value: 2), 4, "Returns last index of element in array")
     }
 
     func testContains() {
-        XCTAssert($.contains([1, 2, 3, 1, 2, 3], value: 2) == true, "Checks if array contains element")
-        XCTAssert($.contains([1, 2, 3, 1, 2, 3], value: 10) == false, "Checks if array contains element")
+        XCTAssertTrue($.contains([1, 2, 3, 1, 2, 3], value: 2), "Checks if array contains element")
+        XCTAssertFalse($.contains([1, 2, 3, 1, 2, 3], value: 10), "Checks if array contains element")
     }
 
     func testRange() {
-        var test = $.range(4)
-        XCTAssert(test == [0, 1, 2, 3], "Generates range")
-        
-        test = $.range(1, endVal: 5)
-        XCTAssert(test == [1, 2, 3, 4], "Generates range")
-            
-        test = $.range(0, endVal: 20, incrementBy: 5)
-        XCTAssert(test == [0, 5, 10, 15], "Generates range")
-        
-        var testDouble = $.range(4.0)
-        XCTAssert(testDouble == [0.0, 1.0, 2.0, 3.0], "Generates range of doubles")
-        
-        testDouble = $.range(-2.0, endVal: 2.0)
-        XCTAssert(testDouble == [-2.0, -1.0, 0.0, 1.0], "Generates range of doubles")
-        
-        testDouble = $.range(-10.0, endVal: 10.0, incrementBy: 5)
-        XCTAssert(testDouble == [-10.0, -5.0, 0.0, 5.0], "Generates range of doubles")
+        XCTAssertEqualObjects($.range(4), [0, 1, 2, 3], "Generates range")
+        XCTAssertEqualObjects($.range(1, endVal: 5), [1, 2, 3, 4], "Generates range")
+        XCTAssertEqualObjects($.range(0, endVal: 20, incrementBy: 5), [0, 5, 10, 15], "Generates range")
+        XCTAssertEqualObjects($.range(4.0), [0.0, 1.0, 2.0, 3.0], "Generates range of doubles")
+        XCTAssertEqualObjects($.range(-2.0, endVal: 2.0), [-2.0, -1.0, 0.0, 1.0], "Generates range of doubles")
+        XCTAssertEqualObjects($.range(-10.0, endVal: 10.0, incrementBy: 5), [-10.0, -5.0, 0.0, 5.0], "Generates range of doubles")
     }
 
     func testSequence() {
-        XCTAssert($.sequence(0..4) == [0, 1, 2, 3], "Generates array of integers")
-        XCTAssert($.sequence(-2.0..2.0) == [-2.0, -1.0, 0.0, 1.0], "Generates array of doubles")
-        XCTAssert($.sequence((0..20).by(5)) == [0, 5, 10, 15], "Generates array with offset")
+        XCTAssertEqualObjects($.sequence(0..4), [0, 1, 2, 3], "Generates array of integers")
+        XCTAssertEqualObjects($.sequence(-2.0..2.0), [-2.0, -1.0, 0.0, 1.0], "Generates array of doubles")
+        XCTAssertEqualObjects($.sequence((0..20).by(5)), [0, 5, 10, 15], "Generates array with offset")
+        // FIXME: EXC_BAD_INSTRUCTION (code=EXC_i386_INVOP, subcode=0x0) when "abc' is used with AssertEqualObjects
+        // XCTAssertEqualObjects($.sequence("abc"), ["a", "b", "c"], "Generates array of characters")
         XCTAssert($.sequence("abc") == ["a", "b", "c"], "Generates array of characters")
     }
 
     func testRemove() {
-        XCTAssert($.remove([1, 2, 3, 4, 5, 6], iterator: { $0 == 2 || $0 == 3 }) == [1, 4, 5, 6], "Remove based on callback")
+        XCTAssertEqualObjects($.remove([1, 2, 3, 4, 5, 6], iterator: { $0 == 2 || $0 == 3 }), [1, 4, 5, 6], "Remove based on callback")
     }
 
     func testSortedIndex() {
-        XCTAssert($.sortedIndex([3, 4, 6, 10], value: 5) == 2, "Index to insert element at in a sorted array")
-        XCTAssert($.sortedIndex([10, 20, 30, 50], value: 40) == 3, "Index to insert element at in a sorted array")
+        XCTAssertEqual($.sortedIndex([3, 4, 6, 10], value: 5), 2, "Index to insert element at in a sorted array")
+        XCTAssertEqual($.sortedIndex([10, 20, 30, 50], value: 40), 3, "Index to insert element at in a sorted array")
     }
 
     func testWithout() {
-        XCTAssert($.without([3, 4, 5, 3, 5], values: 3, 5) == [4], "Removes elements passed after the array")
-        XCTAssert($.without([3, 4, 5, 3, 5], values: 4) == [3, 5, 3, 5], "Removes elements passed after the array")
-        XCTAssert($.without([3, 4, 5, 3, 5], values: 3, 4, 5) == [], "Removes elements passed after the array")
+        XCTAssertEqualObjects($.without([3, 4, 5, 3, 5], values: 3, 5), [4], "Removes elements passed after the array")
+        XCTAssertEqualObjects($.without([3, 4, 5, 3, 5], values: 4), [3, 5, 3, 5], "Removes elements passed after the array")
+        XCTAssertEqualObjects($.without([3, 4, 5, 3, 5], values: 3, 4, 5), [], "Removes elements passed after the array")
     }
 
     func testPull() {
-        XCTAssert($.pull([3, 4, 5, 3, 5], values: 3, 5) as Int[] == [4], "Removes elements passed after the array")
-        XCTAssert($.pull([3, 4, 5, 3, 5], values: 4) as Int[] == [3, 5, 3, 5], "Removes elements passed after the array")
-        XCTAssert($.pull([3, 4, 5, 3, 5], values: 3, 4, 5) == [], "Removes elements passed after the array")
+        XCTAssertEqualObjects($.pull([3, 4, 5, 3, 5], values: 3, 5), [4], "Removes elements passed after the array")
+        XCTAssertEqualObjects($.pull([3, 4, 5, 3, 5], values: 4), [3, 5, 3, 5], "Removes elements passed after the array")
+        XCTAssertEqualObjects($.pull([3, 4, 5, 3, 5], values: 3, 4, 5), [], "Removes elements passed after the array")
     }
 
     func testZip() {
-        XCTAssert($.zip(["fred", "barney"], [30, 40], [true, false]) as NSObject[] == [["fred", 30, true], ["barney", 40, false]], "Zip up arrays")
+        XCTAssertEqualObjects($.zip(["fred", "barney"], [30, 40], [true, false]) as NSObject[], [["fred", 30, true], ["barney", 40, false]], "Zip up arrays")
     }
 
     func testZipObject() {
-        XCTAssert($.zipObject(["fred", "barney"], values: [30, 40]) as Dictionary<String, Int> == ["fred": 30, "barney": 40], "Zip up array to object")
+        XCTAssertEqualObjects($.zipObject(["fred", "barney"], values: [30, 40]) as Dictionary<String, Int>, ["fred": 30, "barney": 40], "Zip up array to object")
     }
 
     func testIntersection() {
-        XCTAssert($.intersection([1, 2, 3], [5, 2, 1, 4], [2, 1]) == [1, 2], "Intersection of arrays")
+        XCTAssertEqualObjects($.intersection([1, 2, 3], [5, 2, 1, 4], [2, 1]), [1, 2], "Intersection of arrays")
     }
 
     func testDifference() {
-        XCTAssert($.difference([1, 2, 3, 4, 5], [5, 2, 10]) == [1, 3, 4], "Difference of arrays")
+        XCTAssertEqualObjects($.difference([1, 2, 3, 4, 5], [5, 2, 10]), [1, 3, 4], "Difference of arrays")
     }
 
     func testUniq() {
-        XCTAssert($.uniq([1, 2, 1, 3, 1]) == [1, 2, 3], "Uniq of arrays")
+        XCTAssertEqualObjects($.uniq([1, 2, 1, 3, 1]), [1, 2, 3], "Uniq of arrays")
     }
 
     func testUnion() {
-        XCTAssert($.union([1, 2, 3], [5, 2, 1, 4], [2, 1]) == [1, 2, 3, 4, 5], "Union of arrays")
+        XCTAssertEqualObjects($.union([1, 2, 3], [5, 2, 1, 4], [2, 1]), [1, 2, 3, 4, 5], "Union of arrays")
     }
 
     func testXOR() {
-        XCTAssert($.xor([1, 2, 3], [5, 2, 1, 4]) == [3, 4, 5], "Xor of arrays")
+        XCTAssertEqualObjects($.xor([1, 2, 3], [5, 2, 1, 4]), [3, 4, 5], "Xor of arrays")
     }
 
     func testAt() {
-        XCTAssert($.at(["ant", "bat", "cat", "dog", "egg"], indexes: 0, 2, 4) == ["ant", "cat", "egg"], "At of arrays")
+        XCTAssertEqualObjects($.at(["ant", "bat", "cat", "dog", "egg"], indexes: 0, 2, 4), ["ant", "cat", "egg"], "At of arrays")
     }
 
     func testEvery() {
-        XCTAssert($.every([1, 2, 3, 4], iterator: { $0 < 20 }) == true, "All elements in collection are true")
-        XCTAssert($.every([1, 2, 3, 4], iterator: { $0 == 1 }) == false, "All elements in collection are true")
+        XCTAssertTrue($.every([1, 2, 3, 4]) { $0 < 20 }, "All elements in collection are true")
+        XCTAssertFalse($.every([1, 2, 3, 4]) { $0 == 1 }, "All elements in collection are true")
     }
 
     func testFind() {
-        XCTAssert($.find([1, 2, 3, 4], iterator: { $0 == 2 }) == 2, "Return element when object is found")
-        XCTAssert($.find([1, 2, 3, 4], iterator: { $0 == 10 }) == nil, "Return nil when object not found")
+        XCTAssertEqualObjects($.find([1, 2, 3, 4], iterator: { $0 == 2 }), 2, "Return element when object is found")
+        XCTAssertNil($.find([1, 2, 3, 4], iterator: { $0 == 10 }), "Return nil when object not found")
     }
 
     func testMax() {
@@ -186,102 +172,97 @@ class DollarTests: XCTestCase {
     }
 
     func testSample() {
-        let arr : Int[] = [2, 1, 2, 3, 4]
-        XCTAssert($.contains(arr, value: $.sample(arr)), "Returns sample which is an element from the array")
+        let arr = [2, 1, 2, 3, 4]
+        XCTAssertTrue($.contains(arr, value: $.sample(arr)), "Returns sample which is an element from the array")
     }
 
     func testPluck() {
         let arr = [["age": 20], ["age": 30], ["age": 40]]
-        XCTAssert($.pluck(arr, value: "age") == [20, 30, 40], "Returns values from the object where they key is the value")
+        XCTAssertEqualObjects($.pluck(arr, value: "age"), [20, 30, 40], "Returns values from the object where they key is the value")
     }
 
     func testFrequencies() {
-        XCTAssert($.frequencies(["a", "a", "b", "c", "a", "b"]) == ["a": 3, "b": 2, "c": 1], "Returns correct frequency dictionary")
-
-        let condFreq = $.frequencies([1,2,3,4,5]) { $0 % 2 == 0 }
-        XCTAssert(condFreq == [false: 3, true: 2], "Returns correct frequency dictionary from cond")
+        XCTAssertEqualObjects($.frequencies(["a", "a", "b", "c", "a", "b"]), ["a": 3, "b": 2, "c": 1], "Returns correct frequency dictionary")
+        XCTAssertEqualObjects($.frequencies([1,2,3,4,5]) { $0 % 2 == 0 }, [false: 3, true: 2], "Returns correct frequency dictionary from cond")
     }
 
     func testKeys() {
         let dict = ["Dog": 1, "Cat": 2]
-        XCTAssert($.keys(dict) == ["Dog", "Cat"], "Returns correct array with keys")
+        XCTAssertEqualObjects($.keys(dict), ["Dog", "Cat"], "Returns correct array with keys")
     }
 
     func testValues() {
         let dict = ["Dog": 1, "Cat": 2]
-        XCTAssert($.values(dict) == [1, 2], "Returns correct array with values")
+        XCTAssertEqualObjects($.values(dict), [1, 2], "Returns correct array with values")
     }
     
     func testMerge() {
         let dict  = ["Dog": 1, "Cat": 2]
         let dict2 = ["Cow": 3]
         let dict3 = ["Sheep": 4]
-        XCTAssert($.merge(dictionaries: dict, dict2, dict3) == ["Dog": 1, "Cat": 2, "Cow": 3, "Sheep": 4], "Returns correct merged dictionary")
+        XCTAssertEqualObjects($.merge(dictionaries: dict, dict2, dict3), ["Dog": 1, "Cat": 2, "Cow": 3, "Sheep": 4], "Returns correct merged dictionary")
 
         let arr  = [1, 5]
         let arr2 = [2, 4]
         let arr3 = [5, 6]
-        let test = $.merge(arrays: arr, arr2, arr3)
-        XCTAssert(test == [1, 5, 2, 4, 5, 6], "Returns correct merged array")
+        XCTAssertEqualObjects($.merge(arrays: arr, arr2, arr3), [1, 5, 2, 4, 5, 6], "Returns correct merged array")
     }
 
     func testPick() {
         let dict = ["Dog": 1, "Cat": 2, "Cow": 3]
-        XCTAssert($.pick(dict, keys: "Dog", "Cow") == ["Dog": 1, "Cow": 3], "Returns correct picked dictionary")
+        XCTAssertEqualObjects($.pick(dict, keys: "Dog", "Cow"), ["Dog": 1, "Cow": 3], "Returns correct picked dictionary")
     }
 
     func testOmit() {
         let dict = ["Dog": 1, "Cat": 2, "Cow": 3]
-        XCTAssert($.omit(dict, keys: "Dog") == ["Cat": 2, "Cow": 3], "Returns correct omited dictionary")
+        XCTAssertEqualObjects($.omit(dict, keys: "Dog"), ["Cat": 2, "Cow": 3], "Returns correct omited dictionary")
     }
 
     func testTap() {
         var beatle = CarExample(name: "Fusca")
         $.tap(beatle, {$0.name = "Beatle"}).color = "Blue"
 
-        XCTAssert(beatle.name == "Beatle", "Set the car name")
-        XCTAssert(beatle.color == "Blue", "Set the car color")
+        XCTAssertEqualObjects(beatle.name, "Beatle", "Set the car name")
+        XCTAssertEqualObjects(beatle.color, "Blue", "Set the car color")
     }
 
     func testChaining() {
         var chain = $(array: [1, 2, 3])
-        XCTAssert(chain.first() as Int == 1, "Returns first element which ends the chain")
+        XCTAssertEqual(chain.first() as Int, 1, "Returns first element which ends the chain")
 
         chain = $(array: [[1, 2], 3, [[4], 5]])
-        XCTAssert(chain.flatten().initial(2).value() as Int[] == [1, 2, 3], "Returns flatten array from chaining")
+        XCTAssertEqualObjects(chain.flatten().initial(2).value() as Int[], [1, 2, 3], "Returns flatten array from chaining")
 
         chain = $(array: [[1, 2], 3, [[4], 5]])
-        XCTAssert(chain.initial().flatten().first() as Int == 1, "Returns flatten array from chaining")
+        XCTAssertEqual(chain.initial().flatten().first() as Int, 1, "Returns flatten array from chaining")
 
         chain = $(array: [[1, 2], 3, [[4], 5]])
-        XCTAssert(chain.flatten().map({ (elem) in elem as Int * 10 }).value() as Int[] == [10, 20, 30, 40, 50], "Returns mapped values")
+        XCTAssertEqualObjects(chain.flatten().map({ (elem) in elem as Int * 10 }).value() as Int[], [10, 20, 30, 40, 50], "Returns mapped values")
 
-        XCTAssert(chain.first() as Int == 10, "Returns first element from mapped value")
+        XCTAssertEqual(chain.first() as Int, 10, "Returns first element from mapped value")
 
         var elements: Int[] = []
         chain.each { elements += $0 as Int }
-        XCTAssert(elements as Int[] == [10, 20, 30, 40, 50], "Goes through each element in the array")
+        XCTAssertEqualObjects(elements as Int[], [10, 20, 30, 40, 50], "Goes through each element in the array")
 
-        XCTAssert(chain.all { ($0 as Int) < 100 } == true, "All elements are less than 100")
-        XCTAssert(chain.all { ($0 as Int) < 40 } == false, "All elements are not less than 40")
-        XCTAssert(chain.any { ($0 as Int) < 40 } == true, "At least one element is less than 40")
+        XCTAssertTrue(chain.all { ( $0 as Int) < 100 }, "All elements are less than 100")
+        XCTAssertFalse(chain.all { ($0 as Int) < 40 }, "All elements are not less than 40")
+        XCTAssertTrue(chain.any { ($0 as Int) < 40 }, "At least one element is less than 40")
 
         elements = []
         chain.slice(0, end: 3).each({ elements += $0 as Int})
-        XCTAssert(elements as Int[] == [10, 20, 30], "Chained seld")
+        XCTAssertEqualObjects(elements as Int[], [10, 20, 30], "Chained seld")
 
     }
 
     func testPartial() {
         let partialFunc = $.partial({(T...) in T[0] + " " + T[1] + " from " + T[2] }, "Hello")
-        XCTAssert(partialFunc("World", "Swift") == "Hello World from Swift", "Returns curry function that is evaluated")
+        XCTAssertEqual(partialFunc("World", "Swift"), "Hello World from Swift", "Returns curry function that is evaluated")
     }
-
 
     func testBind() {
         let helloWorldFunc = $.bind({(T...) in T[0] + " " + T[1] + " from " + T[2] }, "Hello", "World", "Swift")
-        XCTAssert(helloWorldFunc() == "Hello World from Swift", "Returns curry function that is evaluated")
-
+        XCTAssertEqual(helloWorldFunc(), "Hello World from Swift", "Returns curry function that is evaluated")
     }
 
     func testTimes() {
@@ -289,7 +270,7 @@ class DollarTests: XCTestCase {
             let people = $.join(names, separator: " from ")
             return "Hello \(people)"
             }, "Ankur", "Swift")
-        XCTAssert($.times(3, function: fun) as String[] == ["Hello Ankur from Swift", "Hello Ankur from Swift", "Hello Ankur from Swift"], "Call a function 3 times")
+        XCTAssertEqualObjects($.times(3, function: fun) as String[], ["Hello Ankur from Swift", "Hello Ankur from Swift", "Hello Ankur from Swift"], "Call a function 3 times")
     }
 
     func testAfter() {
@@ -304,81 +285,54 @@ class DollarTests: XCTestCase {
         for elem in saves {
             asyncSave(completeCallback)
         }
-        XCTAssert(isDone, "Should be done")
+        XCTAssertTrue(isDone, "Should be done")
     }
 
     func testSlice() {
-        var res = $.slice([1,2,3,4,5], start: 0, end: 2)
-        XCTAssert(res == [1, 2], "Slice subarray 0..2")
-        
-        res = $.slice([1,2,3,4,5], start: 0)
-        XCTAssert(res == [1, 2, 3, 4, 5], "Slice at 0 is whole array")
-        
-        res = $.slice([1,2,3,4,5], start: 3)
-        XCTAssert(res == [4, 5], "Slice with start goes till end")
-        
-        res = $.slice([1,2,3,4,5], start: 8)
-        XCTAssert(res == [], "Slice out of bounds is empty")
-        
-        res = $.slice([1,2,3,4,5], start: 8, end: 10)
-        XCTAssert(res == [], "Slice out of bounds is empty")
-        
-        res = $.slice([1,2,3,4,5], start: 8 , end: 2)
-        XCTAssert(res == [], "Slice with end < start is empty")
-        
-        res = $.slice([1,2,3,4,5], start: 3, end: 3)
-        XCTAssert(res == [], "Slice at x and x is empty")
-        
-        res = $.slice([1,2,3,4,5], start: 2, end: 5)
-        XCTAssert(res == [3,4,5], "Slice at x and x is subarray")
-        
+        XCTAssertEqualObjects($.slice([1,2,3,4,5], start: 0, end: 2), [1, 2], "Slice subarray 0..2")
+        XCTAssertEqualObjects($.slice([1,2,3,4,5], start: 0), [1, 2, 3, 4, 5], "Slice at 0 is whole array")
+        XCTAssertEqualObjects($.slice([1,2,3,4,5], start: 3), [4, 5], "Slice with start goes till end")
+        XCTAssertEqualObjects($.slice([1,2,3,4,5], start: 8), [], "Slice out of bounds is empty")
+        XCTAssertEqualObjects($.slice([1,2,3,4,5], start: 8, end: 10), [], "Slice out of bounds is empty")
+        XCTAssertEqualObjects($.slice([1,2,3,4,5], start: 8 , end: 2), [], "Slice with end < start is empty")
+        XCTAssertEqualObjects($.slice([1,2,3,4,5], start: 3, end: 3), [], "Slice at x and x is empty")
+        XCTAssertEqualObjects($.slice([1,2,3,4,5], start: 2, end: 5), [3,4,5], "Slice at x and x is subarray")
     }
     
-    /// Helper function for testing partition, Swift cannot compare nested arrays.
-    func compareNestedArray(first: Array<Array<Int>>, with second: Array<Array<Int>>) -> Bool {
-        if first.count != second.count { return false }
-        for i in 0..first.count {
-            if first[i] != second[i] { return false }
-        }
-        return true
-    }
-
     func testPartition() {
         var array = [1, 2, 3, 4, 5]
-
-        XCTAssert(compareNestedArray($.partition(array, n: 2), with: [[1, 2], [3, 4]]), "Partition uses n for step if not supplied.")
-        XCTAssert(compareNestedArray($.partition(array, n: 2, step: 1), with: [[1, 2], [2, 3], [3, 4], [4, 5]]), "Partition allows specifying a custom step.")
-        XCTAssert(compareNestedArray($.partition(array, n: 2, step: 1, pad: nil), with: [[1, 2], [2, 3], [3, 4], [4, 5], [5]]), "Partition with nil pad allows the last partition to be less than n length")
-        XCTAssert(compareNestedArray($.partition(array, n: 4, step: 1, pad: nil), with: [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5]]), "Partition with nil pad stops at the first partition less than n length.")
-        XCTAssert(compareNestedArray($.partition(array, n: 2, step: 1, pad: [6,7,8]), with: [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]]), "Partition pads the last partition to the right length.")
-        XCTAssert(compareNestedArray($.partition(array, n: 4, step: 3, pad: [6]), with: [[1, 2, 3, 4], [4, 5, 6]]), "Partition doesn't add more elements than pad has.")
-        XCTAssert(compareNestedArray($.partition([1, 2, 3, 4, 5], n: 2, pad: [6]), with: [[1, 2], [3, 4], [5, 6]]), "Partition with pad and no step uses n as step.")
-        XCTAssert(compareNestedArray($.partition([1, 2, 3, 4, 5, 6], n: 2, step: 4), with: [[1, 2], [5, 6]]), "Partition step length works.")
-        XCTAssert(compareNestedArray($.partition(array, n: 10), with: [[]]), "Partition without pad returns [[]] if n is longer than array.")
+        
+        XCTAssertEqualObjects($.partition(array, n: 2), [[1, 2], [3, 4]], "Partition uses n for step if not supplied.")
+        XCTAssertEqualObjects($.partition(array, n: 2, step: 1), [[1, 2], [2, 3], [3, 4], [4, 5]], "Partition allows specifying a custom step.")
+        XCTAssertEqualObjects($.partition(array, n: 2, step: 1, pad: nil), [[1, 2], [2, 3], [3, 4], [4, 5], [5]], "Partition with nil pad allows the last partition to be less than n length")
+        XCTAssertEqualObjects($.partition(array, n: 4, step: 1, pad: nil), [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5]], "Partition with nil pad stops at the first partition less than n length.")
+        XCTAssertEqualObjects($.partition(array, n: 2, step: 1, pad: [6,7,8]), [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]], "Partition pads the last partition to the right length.")
+        XCTAssertEqualObjects($.partition(array, n: 4, step: 3, pad: [6]), [[1, 2, 3, 4], [4, 5, 6]], "Partition doesn't add more elements than pad has.")
+        XCTAssertEqualObjects($.partition([1, 2, 3, 4, 5], n: 2, pad: [6]), [[1, 2], [3, 4], [5, 6]], "Partition with pad and no step uses n as step.")
+        XCTAssertEqualObjects($.partition([1, 2, 3, 4, 5, 6], n: 2, step: 4), [[1, 2], [5, 6]], "Partition step length works.")
+        XCTAssertEqualObjects($.partition(array, n: 10), [[]], "Partition without pad returns [[]] if n is longer than array.")
     }
     
     func testPartitionAll() {
         var array = [1, 2, 3, 4, 5]
 
-        XCTAssert(compareNestedArray($.partitionAll(array, n: 2, step: 1), with: [[1, 2], [2, 3], [3, 4], [4, 5], [5]]), "PartitionAll includes partitions less than n.")
-        XCTAssert(compareNestedArray($.partitionAll(array, n: 2), with: [[1, 2], [3, 4], [5]]), "PartitionAll uses n as the step when not supplied.")
-        XCTAssert(compareNestedArray($.partitionAll(array, n:4, step: 1), with: [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5], [4, 5], [5]]), "PartitionAll does not stop at the first partition less than n length.")
+        XCTAssertEqualObjects($.partitionAll(array, n: 2, step: 1), [[1, 2], [2, 3], [3, 4], [4, 5], [5]], "PartitionAll includes partitions less than n.")
+        XCTAssertEqualObjects($.partitionAll(array, n: 2), [[1, 2], [3, 4], [5]], "PartitionAll uses n as the step when not supplied.")
+        XCTAssertEqualObjects($.partitionAll(array, n:4, step: 1), [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5], [4, 5], [5]], "PartitionAll does not stop at the first partition less than n length.")
     }
     
     func testPartitionBy() {
-        XCTAssert(compareNestedArray($.partitionBy([1, 2, 3, 4, 5]) { $0 > 10 }, with: [[1, 2, 3, 4, 5]]), "PartitionBy doesn't try to split unnecessarily.")
-        XCTAssert(compareNestedArray($.partitionBy([1, 2, 4, 3, 5, 6]) { $0 % 2 == 0 }, with: [[1], [2, 4], [3, 5], [6]]), "PartitionBy splits appropriately on Bool.")
-        XCTAssert(compareNestedArray($.partitionBy([1, 7, 3, 6, 10, 12]) { $0 % 3 }, with: [[1, 7], [3, 6], [10], [12]]), "PartitionBy can split on functions other than Bool.")
+        XCTAssertEqualObjects($.partitionBy([1, 2, 3, 4, 5]) { $0 > 10 }, [[1, 2, 3, 4, 5]], "PartitionBy doesn't try to split unnecessarily.")
+        XCTAssertEqualObjects($.partitionBy([1, 2, 4, 3, 5, 6]) { $0 % 2 == 0 }, [[1], [2, 4], [3, 5], [6]], "PartitionBy splits appropriately on Bool.")
+        XCTAssertEqualObjects($.partitionBy([1, 7, 3, 6, 10, 12]) { $0 % 3 }, [[1, 7], [3, 6], [10], [12]], "PartitionBy can split on functions other than Bool.")
     }
     
     func testMap() {
-        let result = $.map([1, 2, 3, 4, 5]) { $0 * 2 }
-        XCTAssert(result == [2, 4, 6, 8, 10], "Map function should double values in the array")
+        XCTAssertEqualObjects($.map([1, 2, 3, 4, 5]) { $0 * 2 }, [2, 4, 6, 8, 10], "Map function should double values in the array")
     }
 
     func testReduce() {
-        XCTAssert($.reduce([1, 2, 3, 4, 5], initial: 0) { $0 + $1 } == 15, "Reduce function should sum elements in the array")
+        XCTAssertEqual($.reduce([1, 2, 3, 4, 5], initial: 0) { $0 + $1 }, 15, "Reduce function should sum elements in the array")
     }
 
-    
 }


### PR DESCRIPTION
The temporary variable assignment isn't required when using the
XCTAssertEqualObjects assertion. It seems EqualObjects is required
when comparing an array or a nillable T? type.

This uses XTAssertNil, True, or False where appropriate as well.
