### PR TITLE
Fix half range operator syntax change

### DIFF
--- a/Cent/Cent/Int.swift
+++ b/Cent/Cent/Int.swift
@@ -15,7 +15,7 @@ extension Int {
     ///
     /// :param callback The function to invoke that accepts the index
     func times(callback: (Int) -> ()) {
-        (0...self).eachWithIndex { callback($0) }
+        (0..<self).eachWithIndex { callback($0) }
     }
     
     /// Invoke a callback n times

--- a/Dollar/Dollar/Dollar.swift
+++ b/Dollar/Dollar/Dollar.swift
@@ -263,7 +263,7 @@ class Dollar {
         }
         return { f()? }
     }
-
+    
     /// Creates an array of elements from the specified indexes, or keys, of the collection.
     /// Indexes may be specified as individual arguments or as arrays of indexes.
     ///
@@ -345,7 +345,7 @@ class Dollar {
             }
         }
         for (key, count) in map {
-            for _ in 0...count {
+            for _ in 0..<count {
                 result += key
             }
         }
@@ -551,8 +551,8 @@ class Dollar {
         return resultArr
     }
     
-    /// This method returns a dictionary of values in an array mapping to the 
-    /// total number of occurrences in the array. 
+    /// This method returns a dictionary of values in an array mapping to the
+    /// total number of occurrences in the array.
     ///
     /// :param array The array to source from.
     /// :return Dictionary that contains the key generated from the element passed in the function.
@@ -605,7 +605,7 @@ class Dollar {
     class func initial<T>(array: [T], numElements: Int = 1) -> [T] {
         var result: [T] = []
         if (array.count > numElements) {
-            for index in 0...(array.count - numElements) {
+            for index in 0..<(array.count - numElements) {
                 result += array[index]
             }
         }
@@ -719,7 +719,7 @@ class Dollar {
         }
         return funcRef
     }
-
+    
     /// Merge dictionaries together, later dictionaries overiding earlier values of keys.
     ///
     /// :param dictionaries The dictionaries to source from.
@@ -808,7 +808,7 @@ class Dollar {
         if n > array.count { return [[]] }
         
         for i in (0...array.count-n).by(step!) {
-            result += Array(array[i...(i+n)] as Slice<T>)
+            result += Array(array[i..<(i+n)] as Slice<T>)
         }
         return result
     }
@@ -828,7 +828,7 @@ class Dollar {
         if step < 1 { step = 1 } // Less than 1 results in an infinite loop.
         if n < 1    { n = 0 }    // Allow 0 if user wants [[],[],[]] for some reason.
         
-        for i in (0...array.count).by(step!) {
+        for i in (0..<array.count).by(step!) {
             var end = i+n
             if end > array.count { end = array.count }
             result += Array(array[i...end] as Slice<T>)
@@ -838,7 +838,7 @@ class Dollar {
         if let padding = pad {
             let remain = array.count%n
             let end = padding.count > remain ? remain : padding.count
-            result[result.count-1] += Array(padding[0...end] as Slice<T>)
+            result[result.count-1] += Array(padding[0..<end] as Slice<T>)
         }
         return result
     }
@@ -855,10 +855,10 @@ class Dollar {
         if step < 1 { step = 1 } // Less than 1 results in an infinite loop.
         if n < 1    { n = 0 }    // Allow 0 if user wants [[],[],[]] for some reason.
         
-        for i in (0...array.count).by(step!) {
+        for i in (0..<array.count).by(step!) {
             var end = i+n
             if end > array.count { end = array.count }
-            result += Array(array[i...end] as Slice<T>)
+            result += Array(array[i..<end] as Slice<T>)
         }
         return result
     }
@@ -954,7 +954,7 @@ class Dollar {
     /// :param incrementBy Increment sequence by.
     /// :return Array of elements based on the sequence.
     class func range<T : ForwardIndex>(startVal: T, endVal: T, incrementBy: T.DistanceType) -> [T] {
-        let range = (startVal...endVal).by(incrementBy)
+        let range = (startVal..<endVal).by(incrementBy)
         return self.sequence(range)
     }
     
@@ -993,7 +993,7 @@ class Dollar {
     class func rest<T>(array: [T], numElements: Int = 1) -> [T] {
         var result : [T] = []
         if (numElements < array.count) {
-            for index in numElements...array.count {
+            for index in numElements..<array.count {
                 result += array[index]
             }
         }
@@ -1023,7 +1023,7 @@ class Dollar {
         if end > array.count || start > array.count || uend < start {
             return [];
         } else {
-            return Array(array[start...uend]);
+            return Array(array[start..<uend]);
         }
     }
     
@@ -1051,7 +1051,7 @@ class Dollar {
         return object
     }
     
-    /// Call a function n times and also passes the index. If a value is returned 
+    /// Call a function n times and also passes the index. If a value is returned
     /// in the function then the times method will return an array of those values.
     ///
     /// :param n Number of times to call function.
@@ -1082,7 +1082,7 @@ class Dollar {
     /// :return Values returned from callback function.
     class func times<T>(n: Int, function: (Int) -> T) -> [T] {
         var result : [T] = []
-        for index in (0...n) {
+        for index in (0..<n) {
             result += function(index)
         }
         return result
@@ -1163,7 +1163,7 @@ class Dollar {
         return result
     }
     
-    /// Creates an array of grouped elements, the first of which contains the first elements 
+    /// Creates an array of grouped elements, the first of which contains the first elements
     /// of the given arrays.
     ///
     /// :param arrays The arrays to be grouped.


### PR DESCRIPTION
In Xcode 6b3 the syntax of the half range operator changed to `..<`. It
was mistakenly converted to `...`
