### PR TITLE
$.find shouldn't force the array's elements to be Equatable

### DIFF
--- a/Dollar/Dollar/Dollar.swift
+++ b/Dollar/Dollar/Dollar.swift
@@ -438,7 +438,7 @@ public class Dollar {
     /// :param array The array to search for the element in.
     /// :param iterator The iterator function to tell whether element is found.
     /// :return Optional containing either found element or nil.
-    public class func find<T: Equatable>(array: [T], iterator: (T) -> Bool) -> T? {
+    public class func find<T>(array: [T], iterator: (T) -> Bool) -> T? {
         for elem in array {
             let result = iterator(elem)
             if result {


### PR DESCRIPTION
Why do we force $.find array elements to be equatable?   thats the iterator's job to do the equality testing.
Imagine I have an array of Person (not equatable) and I want to find the first person who's age is over 32?
something like $.find(people, { $0.age > 32 } )

$.findIndex doesn't have this requirement and I don't see a reason for $.find to behave differently...
