### PR TITLE
Remove # from merge functions

### DIFF
--- a/Dollar/Dollar/Dollar.swift
+++ b/Dollar/Dollar/Dollar.swift
@@ -575,7 +575,7 @@ public class $ {
     ///
     /// :param dictionaries The dictionaries to source from.
     /// :return Merged dictionary with all of its keys and values.
-    public class func merge<T, U>(#dictionaries: [T: U]...) -> [T: U] {
+    public class func merge<T, U>(dictionaries: [T: U]...) -> [T: U] {
         var result = [T: U]()
         for dict in dictionaries {
             for (key, value) in dict {
@@ -589,7 +589,7 @@ public class $ {
     ///
     /// :param arrays The arrays to source from.
     /// :return Array with all values merged, including duplicates.
-    public class func merge<T>(#arrays: [T]...) -> [T] {
+    public class func merge<T>(arrays: [T]...) -> [T] {
         var result = [T]()
         for arr in arrays {
             result += arr

--- a/Dollar/DollarTests/DollarTests.swift
+++ b/Dollar/DollarTests/DollarTests.swift
@@ -235,12 +235,12 @@ class DollarTests: XCTestCase {
         let dict  = ["Dog": 1, "Cat": 2]
         let dict2 = ["Cow": 3]
         let dict3 = ["Sheep": 4]
-        XCTAssertTrue($.merge(dictionaries: dict, dict2, dict3) == ["Dog": 1, "Cat": 2, "Cow": 3, "Sheep": 4], "Returns correct merged dictionary")
+        XCTAssertTrue($.merge(dict, dict2, dict3) == ["Dog": 1, "Cat": 2, "Cow": 3, "Sheep": 4], "Returns correct merged dictionary")
 
         let arr  = [1, 5]
         let arr2 = [2, 4]
         let arr3 = [5, 6]
-        XCTAssertEqual($.merge(arrays: arr, arr2, arr3), [1, 5, 2, 4, 5, 6], "Returns correct merged array")
+        XCTAssertEqual($.merge(arr, arr2, arr3), [1, 5, 2, 4, 5, 6], "Returns correct merged array")
     }
 
     func testPick() {

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ Creates an array of all values, including duplicates, of the arrays in the order
 let arr  = [1, 5]
 let arr2 = [2, 4]
 let arr3 = [5, 6]
-let result = $.merge(arrays: arr, arr2, arr3)
+let result = $.merge(arr, arr2, arr3)
 result
 => [1, 5, 2, 4, 5, 6]
 ```
@@ -601,7 +601,7 @@ Merges all of the dictionaries together and the latter dictionary overrides the 
 let dict: Dictionary<String, Int> = ["Dog": 1, "Cat": 2]
 let dict2: Dictionary<String, Int> = ["Cow": 3]
 let dict3: Dictionary<String, Int> = ["Sheep": 4]
-$.merge(dictionaries: dict, dict2, dict3)
+$.merge(dict, dict2, dict3)
 => ["Dog": 1, "Cat": 2, "Cow": 3, "Sheep": 4]
 ```
 


### PR DESCRIPTION
Since Swift will detect collection type we can remove the array/dictionary keyword argument for more conciseness