### PR TITLE
Adds flatMap and equals for optionals.

### DIFF
--- a/Cent/Cent.xcodeproj/project.pbxproj
+++ b/Cent/Cent.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		9299310D19F747F600150D45 /* Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D0253F19F73F6B00A8F5E3 /* Regex.swift */; };
 		9299310E19F747F600150D45 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920C56A319625401009D5129 /* Range.swift */; };
 		92D0254019F73F6B00A8F5E3 /* Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D0253F19F73F6B00A8F5E3 /* Regex.swift */; };
+		C9035E0E1AA614FF008F36EA /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9035E0D1AA614FF008F36EA /* Optional.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		925CB1F11A3FE9ED004F1319 /* Dollar.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Dollar.xcodeproj; path = ../Dollar/Dollar.xcodeproj; sourceTree = "<group>"; };
 		92D0253F19F73F6B00A8F5E3 /* Regex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Regex.swift; sourceTree = "<group>"; };
 		92E6688119F0B89600BB4FB8 /* CentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9035E0D1AA614FF008F36EA /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -139,6 +141,7 @@
 				920C569F196251D7009D5129 /* String.swift */,
 				92D0253F19F73F6B00A8F5E3 /* Regex.swift */,
 				920C56A319625401009D5129 /* Range.swift */,
+				C9035E0D1AA614FF008F36EA /* Optional.swift */,
 				924F92DF195F8338003DBB60 /* Supporting Files */,
 			);
 			path = Cent;
@@ -317,6 +320,7 @@
 				920C56A419625401009D5129 /* Range.swift in Sources */,
 				920C56A0196251D7009D5129 /* String.swift in Sources */,
 				920C569C1962514E009D5129 /* Dictionary.swift in Sources */,
+				C9035E0E1AA614FF008F36EA /* Optional.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cent/Cent/Optional.swift
+++ b/Cent/Cent/Optional.swift
@@ -1,0 +1,14 @@
+//
+//  Optional.swift
+//  
+//
+//  Created by Harlan Haskins on 3/3/15.
+//
+//
+
+import Foundation
+import Dollar
+
+func ==<T: Equatable>(value: T?, other: T?) -> Bool {
+    return $.equal(value, other)
+}

--- a/Cent/CentTests/CentTests.swift
+++ b/Cent/CentTests/CentTests.swift
@@ -36,4 +36,9 @@ class CentTests: XCTestCase {
         XCTAssertEqual(Swift.join("", arr), "ABC", "Return string concatenated")
     }
     
+    func testEqual() {
+        XCTAssert(Optional("hello") == Optional("hello"), "optionalString and otherOptionalString should be equal.")
+        XCTAssert(Optional("hello") != Optional("goodbye"), "optionalString and thirdOptionalString should not be equal.")
+        XCTAssert(nil as String? == nil as String?, "Nil optionals should be equal.")
+    }
 }

--- a/Dollar.xcworkspace/contents.xcworkspacedata
+++ b/Dollar.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Cent/Cent/Optional.swift">
+   </FileRef>
+   <FileRef
       location = "group:Dollar/Dollar.xcodeproj">
    </FileRef>
    <FileRef

--- a/Dollar/Dollar/Dollar.swift
+++ b/Dollar/Dollar/Dollar.swift
@@ -408,7 +408,7 @@ public class $ {
         if let unwrapped = value.map(f) {
             return unwrapped
         } else {
-            return nil
+            return .None
         }
     }
     

--- a/Dollar/Dollar/Dollar.swift
+++ b/Dollar/Dollar/Dollar.swift
@@ -242,6 +242,24 @@ public class $ {
         return array
     }
     
+    /// Checks if two optionals containing Equatable types are equal.
+    ///
+    /// :param value The first optional to check.
+    /// :param other The second optional to check.
+    /// :return: true if the optionals contain two equal values, or both are nil; false otherwise.
+    public class func equal<T: Equatable>(value: T?, _ other: T?) -> Bool {
+        switch (value, other) {
+        case (.None, .None):
+            return true
+        case (.None, .Some(_)):
+            return false
+        case (.Some(_), .None):
+            return false
+        case (.Some(let unwrappedValue), .Some(let otherUnwrappedValue)):
+            return unwrappedValue == otherUnwrappedValue
+        }
+    }
+    
     /// Checks if the given callback returns true value for all items in the array.
     ///
     /// :param array The array to check.
@@ -379,7 +397,19 @@ public class $ {
     /// :param array The array to map.
     /// :return The array with the transformed values concatenated together.
     public class func flatMap<T, U>(array: [T], f: (T) -> ([U])) -> [U] {
-        return array.map(f).reduce([], combine: { $0 + $1 })
+        return array.map(f).reduce([], +)
+    }
+    
+    /// Maps a function that converts a type to an Optional over an Optional, and then returns a single-level Optional.
+    ///
+    /// :param array The array to map.
+    /// :return The array with the transformed values concatenated together.
+    public class func flatMap<T, U>(value: T?, f: (T) -> (U?)) -> U? {
+        if let unwrapped = value.map(f) {
+            return unwrapped
+        } else {
+            return nil
+        }
     }
     
     /// Randomly shuffles the elements of an array.

--- a/Dollar/DollarTests/DollarTests.swift
+++ b/Dollar/DollarTests/DollarTests.swift
@@ -375,7 +375,6 @@ class DollarTests: XCTestCase {
     func testFlatMap() {
         XCTAssertEqual($.flatMap([1, 2, 3]) { [$0, $0] }, [1, 1, 2, 2, 3, 3], "FlatMap should double every item in the array and concatenate them.")
         let expected: String? = "swift"
-        let url = NSURL(string: "https://apple.com/swift/")?.lastPathComponent
         let actual = $.flatMap(NSURL(string: "https://apple.com/swift/")) { $0.lastPathComponent }
         XCTAssert($.equal(actual, expected), "FlatMap on optionals should run the function and produce a single-level optional containing the last path component of the url.")
     }

--- a/Dollar/DollarTests/DollarTests.swift
+++ b/Dollar/DollarTests/DollarTests.swift
@@ -54,6 +54,12 @@ class DollarTests: XCTestCase {
         XCTAssert($.each([1, 3, 4, 5], { arr.append($0 * 2) }) == [1, 3, 4, 5], "Return the array itself")
         XCTAssert(arr == [2, 6, 8, 10], "Return array with doubled numbers")
     }
+    
+    func testEqual() {
+        XCTAssert($.equal(Optional("hello"), Optional("hello")), "optionalString and otherOptionalString should be equal.")
+        XCTAssertFalse($.equal(Optional("hello"), Optional("goodbye")), "optionalString and thirdOptionalString should not be equal.")
+        XCTAssert($.equal(nil as String?, nil as String?), "Nil optionals should be equal.")
+    }
 
     func testFlatten() {
         XCTAssertEqual($.flatten([[3], 4, 5]), [3, 4, 5], "Return flat array")
@@ -368,6 +374,10 @@ class DollarTests: XCTestCase {
     
     func testFlatMap() {
         XCTAssertEqual($.flatMap([1, 2, 3]) { [$0, $0] }, [1, 1, 2, 2, 3, 3], "FlatMap should double every item in the array and concatenate them.")
+        let expected: String? = "swift"
+        let url = NSURL(string: "https://apple.com/swift/")?.lastPathComponent
+        let actual = $.flatMap(NSURL(string: "https://apple.com/swift/")) { $0.lastPathComponent }
+        XCTAssert($.equal(actual, expected), "FlatMap on optionals should run the function and produce a single-level optional containing the last path component of the url.")
     }
     
     func testReduce() {

--- a/README.md
+++ b/README.md
@@ -225,6 +225,24 @@ $.flatMap(values) { [$0, $0] }
 => [2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7]
 ```
 
+### flatMap - `$.flatMap`
+
+Maps a function that converts a type to an Optional over an Optional, and then returns a single-level Optional.
+
+
+```swift
+let url = NSURL(string: "https://apple.com/swift")
+$.flatMap(url) { $0.lastPathComponent }
+=> Optional("swift")
+```
+
+*Note*: This is the same behavior as Optional chaining.
+The code above translates to
+```swift
+NSURL(string: "https://apple.com/swift/")?.lastPathComponent
+=> Optional("swift")
+```
+
 ### flatten - `$.flatten`
 
 Flattens a nested array of any depth.
@@ -971,6 +989,28 @@ $.chain([1, 2, 3, 4, 5])
 => [2, 4, 6]
 ```
 
+## Optional ##
+
+### `equal`
+
+Tells whether two optionals containing Equatable types are equal.
+
+```swift
+let optionalString: String? = "hello"
+let otherOptionalString: String? = "hello"
+$.equal(optionalString, otherOptionalString)
+=> true
+
+let thirdOptionalString: String? = "goodbye"
+$.equal(optionalString, thirdOptionalString)
+=> false
+
+let nilOptionalString: String? = nil
+let otherNilOptionalString: String? = nil
+$.equal(nilOptionalString, otherNilOptionalString)
+=> true
+```
+
 # Cent Usage #
 
 ## Array Extensions ##
@@ -1527,6 +1567,23 @@ For each index in the range invoke the callback
 ```swift
 (1...5).each { print("Na") } 
 => "NaNaNaNaNa"
+```
+
+## Optional Extensions ##
+
+### equals - `==`
+
+Check the equality of two Equatable Optionals
+
+```swift
+Optional("hello") == Optional("hello")
+=> true
+
+Optional("hello") == Optional("goodbye")
+=> false
+
+nil as String? == nil as String?
+=> true
 ```
 
 # Contributing #


### PR DESCRIPTION
flatMap has the same behavior as optional chaining, except specified for Functor completeness.

Adds equality checking for Equatable optionals.
Adds test for equals in Dollar and Cent.
Adds usage descriptions in README.