### PR TITLE
Added date and time math functions.

### DIFF
--- a/Cent/Cent/Int.swift
+++ b/Cent/Cent/Int.swift
@@ -112,3 +112,100 @@ extension Int {
     }
     
 }
+
+public extension Int {
+    struct CalendarMath {
+        private let unit: NSCalendarUnit
+        private let value: Int
+        private var calendar: NSCalendar {
+            return NSCalendar.autoupdatingCurrentCalendar()
+        }
+
+        private init(unit: NSCalendarUnit, value: Int) {
+            self.unit = unit
+            self.value = value
+        }
+
+        private func generateComponents(_ modifer: (Int) -> (Int) = (+)) -> NSDateComponents {
+            let components = NSDateComponents()
+            components.setValue(modifer(value), forComponent: unit)
+            return components
+        }
+
+        public func from(date: NSDate) -> NSDate? {
+            return calendar.dateByAddingComponents(generateComponents(), toDate: date, options: nil)
+        }
+
+        public var fromNow: NSDate? {
+            return from(NSDate())
+        }
+
+        public func before(date: NSDate) -> NSDate? {
+            return calendar.dateByAddingComponents(generateComponents(-), toDate: date, options: nil)
+        }
+
+        public var ago: NSDate? {
+            return before(NSDate())
+        }
+    }
+
+    private func mathForUnit(unit: NSCalendarUnit) -> CalendarMath {
+        return CalendarMath(unit: unit, value: self)
+    }
+
+    var seconds: CalendarMath {
+        return mathForUnit(.CalendarUnitSecond)
+    }
+
+    var second: CalendarMath {
+        return seconds
+    }
+
+    var minutes: CalendarMath {
+        return mathForUnit(.CalendarUnitMinute)
+    }
+
+    var minute: CalendarMath {
+        return minutes
+    }
+
+    var hours: CalendarMath {
+        return mathForUnit(.CalendarUnitHour)
+    }
+
+    var hour: CalendarMath {
+        return hours
+    }
+
+    var days: CalendarMath {
+        return mathForUnit(.CalendarUnitDay)
+    }
+
+    var day: CalendarMath {
+        return days
+    }
+
+    var weeks: CalendarMath {
+        return mathForUnit(.CalendarUnitWeekOfYear)
+    }
+
+    var week: CalendarMath {
+        return weeks
+    }
+
+    var months: CalendarMath {
+        return mathForUnit(.CalendarUnitMonth)
+    }
+
+    var month: CalendarMath {
+        return months
+    }
+
+    var years: CalendarMath {
+        return mathForUnit(.CalendarUnitYear)
+    }
+    
+    var year: CalendarMath {
+        return years
+    }
+}

--- a/Cent/CentTests/CentTests.swift
+++ b/Cent/CentTests/CentTests.swift
@@ -41,4 +41,43 @@ class CentTests: XCTestCase {
         XCTAssert(Optional("hello") != Optional("goodbye"), "optionalString and thirdOptionalString should not be equal.")
         XCTAssert(nil as String? == nil as String?, "Nil optionals should be equal.")
     }
+
+    func testDateMath() {
+        struct TestDate {
+            let unit: NSCalendarUnit
+            let singleMath: Int.CalendarMath
+            let multipleMath: Int.CalendarMath
+        }
+
+        let calendar = NSCalendar.autoupdatingCurrentCalendar()
+        let multiple = 2
+
+        let tests = [
+            TestDate(unit: .CalendarUnitSecond, singleMath: 1.second, multipleMath: multiple.seconds),
+            TestDate(unit: .CalendarUnitMinute, singleMath: 1.minute, multipleMath: multiple.minutes),
+            TestDate(unit: .CalendarUnitHour, singleMath: 1.hour, multipleMath: multiple.hours),
+            TestDate(unit: .CalendarUnitDay, singleMath: 1.day, multipleMath: multiple.days),
+            TestDate(unit: .CalendarUnitWeekOfYear, singleMath: 1.week, multipleMath: multiple.weeks),
+            TestDate(unit: .CalendarUnitMonth, singleMath: 1.month, multipleMath: multiple.months),
+            TestDate(unit: .CalendarUnitYear, singleMath: 1.year, multipleMath: multiple.years)
+        ]
+
+        tests.each { (test) -> () in
+            func equalIsh(lhs: NSDate!, #rhs: NSDate!) -> Bool {
+                return round(lhs.timeIntervalSinceNow) == round(rhs.timeIntervalSinceNow)
+            }
+
+            let components = NSDateComponents()
+            components.setValue(1, forComponent: test.unit)
+
+            XCTAssert(equalIsh(test.singleMath.fromNow, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: nil)), "formNow single units are equal.")
+            components.setValue(-1, forComponent: test.unit)
+            XCTAssert(equalIsh(test.singleMath.ago, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: nil)), "ago single units are equal.")
+
+            components.setValue(multiple, forComponent: test.unit)
+            XCTAssert(equalIsh(test.multipleMath.fromNow, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: nil)), "formNow multiple units are equal.")
+            components.setValue(-multiple, forComponent: test.unit)
+            XCTAssert(equalIsh(test.multipleMath.ago, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: nil)), "ago multiple units are equal.")
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1266,6 +1266,17 @@ let otherUnix = Date.unix(otherDate)
 => 1,388,552,400.0
 ```
 
+### `Int.hour.fromNow` et al.
+
+Use the following syntax to calculate dates and times based on the user's current calendar. 
+
+```swift
+1.day.ago
+=> "Apr 10, 2015, 11:51 AM"
+4.hours.fromNow
+=> "Apr 11, 2015, 3:51 PM"
+```
+
 ## Dictionary Extensions ##
 
 ### `merge<K, V>(dictionaries: Dictionary<K, V>...)`


### PR DESCRIPTION
This adds the following type of syntax to Cent:

```swift
4.hours.ago
1.year.fromNow
```

And so on. 

The implementation uses `NSCalendar`'s `autoupdatingCurrentCalendar()` function to make this automatically localized to the user's location (asking for a day in the future is different for different calendars, leap years, etc). This avoids a more naïve implementation that assumes every minute has 60 seconds, or that every day has 24 hours. 

So here's how the implementation works, and why it was done this way:

Extend `Int` to return an opaque type that stores a unit (year, month, hour, etc) and a value (the underlying `Int`). These two values are private in the type so that no one relies on our implementation, which could change. We need both the unit and the value in order to calculate time ago, since `NSCalendar` only has a function for `dateByAddingComponents`, not `dateBySubtractingComponents`. The solution is to negate the unit when we call this function, but we need to know _which_ unit to negate, so we keep them both.

Fixes #148.