### PR TITLE
Removing bundle resources to fix codesign problem

### DIFF
--- a/Dollar/Dollar.xcodeproj/project.pbxproj
+++ b/Dollar/Dollar.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		924E37D4197DFCDB000086A9 /* Dollar.swift in Resources */ = {isa = PBXBuildFile; fileRef = 92E0D05819467CA2002ACC3D /* Dollar.swift */; };
 		9252FCD21A0F26F6002E85A4 /* AutoCurry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9252FCD11A0F26F6002E85A4 /* AutoCurry.swift */; };
 		925CB1E11A3FDCA4004F1319 /* Dollar.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 92E0D03C19467C67002ACC3D /* Dollar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		92E0D04219467C67002ACC3D /* Dollar.h in Headers */ = {isa = PBXBuildFile; fileRef = 92E0D04119467C67002ACC3D /* Dollar.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -15,7 +14,6 @@
 		92E6687A19F09D2A00BB4FB8 /* CarExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0419C8411948BEC600B947B3 /* CarExample.swift */; };
 		92E6687B19F09D2A00BB4FB8 /* DollarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E0D04E19467C67002ACC3D /* DollarTests.swift */; };
 		92E6687C19F09D3000BB4FB8 /* Dollar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92E0D03C19467C67002ACC3D /* Dollar.framework */; };
-		92F1389D1A0F28C000B72258 /* gen_auto_curry.rb in Resources */ = {isa = PBXBuildFile; fileRef = 92F1389C1A0F28C000B72258 /* gen_auto_curry.rb */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -230,8 +228,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				924E37D4197DFCDB000086A9 /* Dollar.swift in Resources */,
-				92F1389D1A0F28C000B72258 /* gen_auto_curry.rb in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Fixes #150.

Problem is the Dollar.o file included in the framework, which is caused by the extra (unneeded?) bundle resources.

The current built framework has:

    % tree Dollar.framework
    Dollar.framework
    ├── Dollar
    ├── Dollar-OutputFileMap.json
    ├── Dollar-Swift.h
    ├── Dollar-master.swiftdeps
    ├── Dollar.d
    ├── Dollar.dia
    ├── Dollar.o
    ├── Dollar.swiftdeps
    ├── Dollar.swiftdoc
    ├── Dollar.swiftmodule
    ├── Dollar~partial.swiftmodule
    ├── Headers
    │   ├── Dollar-Swift.h
    │   └── Dollar.h
    ├── Info.plist
    ├── Modules
    │   ├── Dollar.swiftmodule
    │   │   ├── arm.swiftdoc
    │   │   ├── arm.swiftmodule
    │   │   ├── arm64.swiftdoc
    │   │   └── arm64.swiftmodule
    │   └── module.modulemap
    ├── _CodeSignature
    │   └── CodeResources
    └── gen_auto_curry.rb
    
    4 directories, 21 files

With changes in PR:

    % tree Dollar.framework
    Dollar.framework
    ├── Dollar
    ├── Headers
    │   ├── Dollar-Swift.h
    │   └── Dollar.h
    ├── Info.plist
    ├── Modules
    │   ├── Dollar.swiftmodule
    │   │   ├── arm.swiftdoc
    │   │   ├── arm.swiftmodule
    │   │   ├── arm64.swiftdoc
    │   │   └── arm64.swiftmodule
    │   └── module.modulemap
    └── _CodeSignature
      └── CodeResources
    
    4 directories, 10 files