### PR TITLE
Updated for Xcode 7 beta 4

### DIFF
--- a/Cent/Cent.xcodeproj/project.pbxproj
+++ b/Cent/Cent.xcodeproj/project.pbxproj
@@ -237,7 +237,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Encore Dev Labs LLC";
 				TargetAttributes = {
 					924F92DB195F8338003DBB60 = {
@@ -372,6 +372,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -459,6 +460,7 @@
 				INFOPLIST_FILE = Cent/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.encoredevlabs.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -485,6 +487,7 @@
 				INFOPLIST_FILE = Cent/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.encoredevlabs.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -507,6 +510,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.encoredevlabs.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -524,6 +528,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.encoredevlabs.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/Cent/Cent.xcodeproj/xcshareddata/xcschemes/Cent.xcscheme
+++ b/Cent/Cent.xcodeproj/xcshareddata/xcschemes/Cent.xcscheme
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -66,11 +66,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -88,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Cent/Cent/Array.swift
+++ b/Cent/Cent/Array.swift
@@ -40,7 +40,7 @@ internal extension Array {
     ///
     /// :param callback The callback function to invoke that take an element
     func eachWithIndex(callback: (Int, Element) -> ()) -> [Element] {
-        for (index, elem) in enumerate(self) {
+        for (index, elem) in enumerate() {
             callback(index, elem)
         }
         return self

--- a/Cent/Cent/Date.swift
+++ b/Cent/Cent/Date.swift
@@ -16,7 +16,7 @@ extension NSDate {
     /// :param month
     /// :param day
     /// :return Date
-    public class func from(#year: Int, month: Int, day: Int) -> NSDate? {
+    public class func from(year year: Int, month: Int, day: Int) -> NSDate? {
         var c = NSDateComponents()
         c.year = year
         c.month = month
@@ -33,7 +33,7 @@ extension NSDate {
     ///
     /// :param unix timestamp
     /// :return Date
-    public class func from(#unix: Double) -> NSDate {
+    public class func from(unix unix: Double) -> NSDate {
         return NSDate(timeIntervalSince1970: unix)
     }
 

--- a/Cent/Cent/Date.swift
+++ b/Cent/Cent/Date.swift
@@ -17,7 +17,7 @@ extension NSDate {
     /// :param day
     /// :return Date
     public class func from(year year: Int, month: Int, day: Int) -> NSDate? {
-        var c = NSDateComponents()
+        let c = NSDateComponents()
         c.year = year
         c.month = month
         c.day = day
@@ -43,7 +43,7 @@ extension NSDate {
     /// :param format By default it is year month day
     /// :return Date
     public class func parse(dateStr: String, format: String = "yyyy-MM-dd") -> NSDate {
-        var dateFmt = NSDateFormatter()
+        let dateFmt = NSDateFormatter()
         dateFmt.timeZone = NSTimeZone.defaultTimeZone()
         dateFmt.dateFormat = format
         return dateFmt.dateFromString(dateStr)!
@@ -54,7 +54,7 @@ extension NSDate {
     ///
     /// :param date
     /// :return Double
-    public class func unix(_ date: NSDate = NSDate()) -> Double {
+    public class func unix(date: NSDate = NSDate()) -> Double {
        return date.timeIntervalSince1970 as Double
     }
 }

--- a/Cent/Cent/Info.plist
+++ b/Cent/Cent/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.encoredevlabs.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Cent/Cent/Int.swift
+++ b/Cent/Cent/Int.swift
@@ -126,7 +126,7 @@ public extension Int {
             self.value = value
         }
 
-        private func generateComponents(_ modifer: (Int) -> (Int) = (+)) -> NSDateComponents {
+        private func generateComponents(modifer: (Int) -> (Int) = (+)) -> NSDateComponents {
             let components = NSDateComponents()
             components.setValue(modifer(value), forComponent: unit)
             return components

--- a/Cent/Cent/Int.swift
+++ b/Cent/Cent/Int.swift
@@ -133,7 +133,7 @@ public extension Int {
         }
 
         public func from(date: NSDate) -> NSDate? {
-            return calendar.dateByAddingComponents(generateComponents(), toDate: date, options: nil)
+            return calendar.dateByAddingComponents(generateComponents(), toDate: date, options: [])
         }
 
         public var fromNow: NSDate? {
@@ -141,7 +141,7 @@ public extension Int {
         }
 
         public func before(date: NSDate) -> NSDate? {
-            return calendar.dateByAddingComponents(generateComponents(-), toDate: date, options: nil)
+            return calendar.dateByAddingComponents(generateComponents(-), toDate: date, options: [])
         }
 
         public var ago: NSDate? {
@@ -154,7 +154,7 @@ public extension Int {
     }
 
     var seconds: CalendarMath {
-        return mathForUnit(.CalendarUnitSecond)
+        return mathForUnit(.Second)
     }
 
     var second: CalendarMath {
@@ -162,7 +162,7 @@ public extension Int {
     }
 
     var minutes: CalendarMath {
-        return mathForUnit(.CalendarUnitMinute)
+        return mathForUnit(.Minute)
     }
 
     var minute: CalendarMath {
@@ -170,7 +170,7 @@ public extension Int {
     }
 
     var hours: CalendarMath {
-        return mathForUnit(.CalendarUnitHour)
+        return mathForUnit(.Hour)
     }
 
     var hour: CalendarMath {
@@ -178,7 +178,7 @@ public extension Int {
     }
 
     var days: CalendarMath {
-        return mathForUnit(.CalendarUnitDay)
+        return mathForUnit(.Day)
     }
 
     var day: CalendarMath {
@@ -186,7 +186,7 @@ public extension Int {
     }
 
     var weeks: CalendarMath {
-        return mathForUnit(.CalendarUnitWeekOfYear)
+        return mathForUnit(.WeekOfYear)
     }
 
     var week: CalendarMath {
@@ -194,7 +194,7 @@ public extension Int {
     }
 
     var months: CalendarMath {
-        return mathForUnit(.CalendarUnitMonth)
+        return mathForUnit(.Month)
     }
 
     var month: CalendarMath {
@@ -202,7 +202,7 @@ public extension Int {
     }
 
     var years: CalendarMath {
-        return mathForUnit(.CalendarUnitYear)
+        return mathForUnit(.Year)
     }
     
     var year: CalendarMath {

--- a/Cent/Cent/Range.swift
+++ b/Cent/Cent/Range.swift
@@ -14,7 +14,7 @@ internal extension Range {
     /// For each index in the range invoke the callback by passing the item in range
     ///
     /// :param callback The callback function to invoke that take an element
-    func eachWithIndex(callback: (T) -> ()) {
+    func eachWithIndex(callback: (Element) -> ()) {
         for index in self {
             callback(index)
         }

--- a/Cent/Cent/Regex.swift
+++ b/Cent/Cent/Regex.swift
@@ -19,17 +19,16 @@ public class Regex {
     
     public init(_ pattern: String) {
         self.pattern = pattern
-        var error: NSError?
-        self.expression = NSRegularExpression(pattern: pattern, options: .CaseInsensitive, error: &error)!
+        self.expression = try! NSRegularExpression(pattern: pattern, options: .CaseInsensitive)
     }
     
     public func matches(testStr: String) -> [AnyObject] {
-        let matches = self.expression.matchesInString(testStr, options: nil, range:NSMakeRange(0, count(testStr)))
+        let matches = self.expression.matchesInString(testStr, options: [], range:NSMakeRange(0, testStr.characters.count))
         return matches
     }
     
     public func rangeOfFirstMatch(testStr: String) -> NSRange {
-        return self.expression.rangeOfFirstMatchInString(testStr, options: nil, range:NSMakeRange(0, count(testStr)))
+        return self.expression.rangeOfFirstMatchInString(testStr, options: [], range:NSMakeRange(0, testStr.characters.count))
     }
     
     public func test(testStr: String) -> Bool {
@@ -39,7 +38,7 @@ public class Regex {
     
     public class func escapeStr(str: String) -> String {
         let matches = RegexPatternRegex.matches(str)
-        var charArr = [Character](str)
+        var charArr = [Character](str.characters)
         var strBuilder = [Character]()
         var i = 0
         for match in matches {

--- a/Cent/Cent/String.swift
+++ b/Cent/Cent/String.swift
@@ -44,8 +44,8 @@ extension String {
     /// :param range The range from which to start and end the substring
     /// :return Substring
     public subscript(range: Range<Int>) -> String {
-        var start = Swift.advance(startIndex, range.startIndex)
-        var end = Swift.advance(startIndex, range.endIndex)
+        let start = Swift.advance(startIndex, range.startIndex)
+        let end = Swift.advance(startIndex, range.endIndex)
         return self.substringWithRange(Range(start: start, end: end))
     }
     

--- a/Cent/Cent/String.swift
+++ b/Cent/Cent/String.swift
@@ -13,7 +13,7 @@ extension String {
     
     public var length: Int {
         get {
-            return count(self)
+            return Int(characters.count)
         }
     }
     
@@ -22,10 +22,10 @@ extension String {
     /// :param i Index for which the character is returned
     /// :return Character at index i
     public subscript(i: Int) -> Character? {
-        if let char = Array(self).get(i) {
-            return char
+        if i > length - 1 {
+            return .None
         }
-        return .None
+        return [Character](characters)[i]
     }
 
     /// Get character at a subscript
@@ -127,6 +127,6 @@ public func * (str: String, n: Int) -> String {
     n.times {
         stringBuilder.append(str)
     }
-    return Swift.join("", stringBuilder)
+    return "".join(stringBuilder)
 }
 

--- a/Cent/CentTests/CentTests.swift
+++ b/Cent/CentTests/CentTests.swift
@@ -34,7 +34,7 @@ class CentTests: XCTestCase {
         var arr: [String] = []
         var result = ["A", "B", "C"].each({ arr.append($0) })
         XCTAssertEqual(result, ["A", "B", "C"], "Return array itself")
-        XCTAssertEqual(Swift.join("", arr), "ABC", "Return string concatenated")
+        XCTAssertEqual("".join(arr), "ABC", "Return string concatenated")
     }
     
     func testDateMath() {
@@ -48,31 +48,31 @@ class CentTests: XCTestCase {
         let multiple = 2
 
         let tests = [
-            TestDate(unit: .CalendarUnitSecond, singleMath: 1.second, multipleMath: multiple.seconds),
-            TestDate(unit: .CalendarUnitMinute, singleMath: 1.minute, multipleMath: multiple.minutes),
-            TestDate(unit: .CalendarUnitHour, singleMath: 1.hour, multipleMath: multiple.hours),
-            TestDate(unit: .CalendarUnitDay, singleMath: 1.day, multipleMath: multiple.days),
-            TestDate(unit: .CalendarUnitWeekOfYear, singleMath: 1.week, multipleMath: multiple.weeks),
-            TestDate(unit: .CalendarUnitMonth, singleMath: 1.month, multipleMath: multiple.months),
-            TestDate(unit: .CalendarUnitYear, singleMath: 1.year, multipleMath: multiple.years)
+            TestDate(unit: .Second, singleMath: 1.second, multipleMath: multiple.seconds),
+            TestDate(unit: .Minute, singleMath: 1.minute, multipleMath: multiple.minutes),
+            TestDate(unit: .Hour, singleMath: 1.hour, multipleMath: multiple.hours),
+            TestDate(unit: .Day, singleMath: 1.day, multipleMath: multiple.days),
+            TestDate(unit: .WeekOfYear, singleMath: 1.week, multipleMath: multiple.weeks),
+            TestDate(unit: .Month, singleMath: 1.month, multipleMath: multiple.months),
+            TestDate(unit: .Year, singleMath: 1.year, multipleMath: multiple.years)
         ]
 
         tests.each { (test) -> () in
-            func equalIsh(lhs: NSDate!, #rhs: NSDate!) -> Bool {
+            func equalIsh(lhs: NSDate!, rhs: NSDate!) -> Bool {
                 return round(lhs.timeIntervalSinceNow) == round(rhs.timeIntervalSinceNow)
             }
 
             let components = NSDateComponents()
             components.setValue(1, forComponent: test.unit)
 
-            XCTAssert(equalIsh(test.singleMath.fromNow, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: nil)), "formNow single units are equal.")
+            XCTAssert(equalIsh(test.singleMath.fromNow, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: [])), "fromNow single units are equal.")
             components.setValue(-1, forComponent: test.unit)
-            XCTAssert(equalIsh(test.singleMath.ago, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: nil)), "ago single units are equal.")
+            XCTAssert(equalIsh(test.singleMath.ago, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: [])), "ago single units are equal.")
 
             components.setValue(multiple, forComponent: test.unit)
-            XCTAssert(equalIsh(test.multipleMath.fromNow, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: nil)), "formNow multiple units are equal.")
+            XCTAssert(equalIsh(test.multipleMath.fromNow, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: [])), "fromNow multiple units are equal.")
             components.setValue(-multiple, forComponent: test.unit)
-            XCTAssert(equalIsh(test.multipleMath.ago, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: nil)), "ago multiple units are equal.")
+            XCTAssert(equalIsh(test.multipleMath.ago, rhs: calendar.dateByAddingComponents(components, toDate: NSDate(), options: [])), "ago multiple units are equal.")
         }
     }
 }

--- a/Cent/CentTests/CentTests.swift
+++ b/Cent/CentTests/CentTests.swift
@@ -32,7 +32,7 @@ class CentTests: XCTestCase {
     
     func testEach() {
         var arr: [String] = []
-        var result = ["A", "B", "C"].each({ arr.append($0) })
+        let result = ["A", "B", "C"].each({ arr.append($0) })
         XCTAssertEqual(result, ["A", "B", "C"], "Return array itself")
         XCTAssertEqual("".join(arr), "ABC", "Return string concatenated")
     }

--- a/Cent/CentTests/Info.plist
+++ b/Cent/CentTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.encoredevlabs.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Dollar/Dollar.xcodeproj/xcshareddata/xcschemes/Dollar.xcscheme
+++ b/Dollar/Dollar.xcodeproj/xcshareddata/xcschemes/Dollar.xcscheme
@@ -37,10 +37,10 @@
       </BuildActionEntry>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -66,11 +66,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -88,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/Dollar/Dollar/Dollar.swift
+++ b/Dollar/Dollar/Dollar.swift
@@ -563,8 +563,17 @@ public class $ {
     /// :param array The array to join the elements of.
     /// :param separator The separator to join the elements with.
     /// :return Joined element from the array of elements.
-    public class func join<T: ExtensibleCollectionType>(array: [T], separator: T) -> T {
+    public class func join<T: RangeReplaceableCollectionType>(array: [T], separator: T) -> T {
         return Swift.join(separator, array)
+    }
+    
+    /// Joins strings in an array with the specified separator
+    ///
+    /// :param array The array to join the elements of.
+    /// :param separator The separator to join the elements with.
+    /// :return Joined element from the array of elements.
+    public class func join(strArray: [String], separator: String) -> String {
+        return separator.join(strArray)
     }
     
     /// Creates an array of keys given a dictionary.
@@ -991,6 +1000,14 @@ public class $ {
     /// :return Array of elements generated from the sequence.
     public class func sequence<S : SequenceType>(seq: S) -> [S.Generator.Element] {
         return Array<S.Generator.Element>(seq)
+    }
+    
+    /// Creates an array of an arbitrary string characters.
+    ///
+    /// :param seq The sequence to generate from.
+    /// :return Array of elements generated from the sequence.
+    public class func sequence(str: String) -> [String] {
+        return str.characters.map { String($0) }
     }
     
     /// Removes all elements from an array that the callback returns true.

--- a/Dollar/DollarTests/DollarTests.swift
+++ b/Dollar/DollarTests/DollarTests.swift
@@ -51,7 +51,7 @@ class DollarTests: XCTestCase {
     
     func testEach() {
         var arr: [Int] = []
-        var result = $.each([1, 3, 4, 5], callback: { arr.append($0 * 2) })
+        let result = $.each([1, 3, 4, 5], callback: { arr.append($0 * 2) })
         XCTAssert(result == [1, 3, 4, 5], "Return the array itself")
         XCTAssert(arr == [2, 6, 8, 10], "Return array with doubled numbers")
     }
@@ -261,7 +261,7 @@ class DollarTests: XCTestCase {
     }
 
     func testTap() {
-        var beatle = CarExample(name: "Fusca")
+        let beatle = CarExample(name: "Fusca")
         $.tap(beatle, function: {$0.name = "Beatle"}).color = "Blue"
 
         XCTAssertEqual(beatle.name!, "Beatle", "Set the car name")
@@ -301,13 +301,12 @@ class DollarTests: XCTestCase {
         let chainB = $.chain(testarr)
         XCTAssertEqual(chainB.initial().flatten().first()!, 1, "Returns flatten array from chaining")
 
-        let chainC = $.chain(testarr)
+        _ = $.chain(testarr)
 //        XCTAssertEqual(chainC.flatten().map({ (elem) in elem as Int * 10 }).value, [10, 20, 30, 40, 50], "Returns mapped values")
 //        XCTAssertEqual(chainC.flatten().map({ (elem) in elem as Int * 10 }).first()!, 100, "Returns first element from mapped value")
     }
 
     func testPartial() {
-        let s = "ABCD"
         let partialFunc = $.partial({(T: String...) in T[0] + " " + T[1] + " from " + T[2] }, "Hello")
         XCTAssertEqual(partialFunc("World", "Swift"), "Hello World from Swift", "Returns curry function that is evaluated")
     }
@@ -331,10 +330,10 @@ class DollarTests: XCTestCase {
             function()
         }
         var isDone = false
-        var completeCallback = $.after(saves.count) {
+        let completeCallback = $.after(saves.count) {
             isDone = true
         }
-        for elem in saves {
+        for _ in saves {
             asyncSave(completeCallback)
         }
         XCTAssertTrue(isDone, "Should be done")
@@ -342,7 +341,7 @@ class DollarTests: XCTestCase {
     
     
     func testPartition() {
-        var array = [1, 2, 3, 4, 5]
+        let array = [1, 2, 3, 4, 5]
         
         XCTAssertEqual($.partition(array, n: 2), [[1, 2], [3, 4]], "Partition uses n for step if not supplied.")
         XCTAssertTrue($.partition(array, n: 2, step: 1) == [[1, 2], [2, 3], [3, 4], [4, 5]], "Partition allows specifying a custom step.")
@@ -356,7 +355,7 @@ class DollarTests: XCTestCase {
     }
 
     func testPartitionAll() {
-        var array = [1, 2, 3, 4, 5]
+        let array = [1, 2, 3, 4, 5]
         
         XCTAssertTrue($.partitionAll(array, n: 2, step: 1) == [[1, 2], [2, 3], [3, 4], [4, 5], [5]], "PartitionAll includes partitions less than n.")
         XCTAssertTrue($.partitionAll(array, n: 2) == [[1, 2], [3, 4], [5]], "PartitionAll uses n as the step when not supplied.")
@@ -402,14 +401,14 @@ class DollarTests: XCTestCase {
             times += 1
             return val == 1 || val == 0 ? 1 : fib(val - 1) + fib(val - 2)
         }
-        let x = fibMemo(5)
+        _ = fibMemo(5)
         XCTAssertEqual(times, 6, "Function called 6 times")
         times = 0
-        let y = fibMemo(5)
+        _ = fibMemo(5)
         XCTAssertEqual(times, 0, "Function called 0 times due to memoize")
 
         times = 0
-        let z = fibMemo(6)
+        _ = fibMemo(6)
         XCTAssertEqual(times, 1, "Function called 1 times due to memoize")
     }
 


### PR DESCRIPTION
@ankurp 

The most important commit is this one: https://github.com/ankurp/Dollar.swift/commit/ecb7c3895a740c285621b86c8387a1514ef0d826

 - `String` is not a `RangeReplaceableCollectionType` anymore, so I added an additional version of `$. join` and `$.sequence` just for the type String.
 - In Swift 2 you can't do stuff like `Array(str)` anymore, you need to look at the underlying `CharacterView`. Fixed that in a couple spots.
 - In Swift 2 you have to pass empty options with `[]` instead of `nil`
 - Calendar units have a different syntax now
 - Fixed other small stuff like implicit argument names

Tests all pass and the Dollar/Cent interface remains the same.

In a second commit I removed all the Xcode warnings (mostly related to variables not being used): https://github.com/ankurp/Dollar.swift/commit/da6e2800353d0bd5896414f835a5ae352156440f

Let me know what you think.